### PR TITLE
Remove the requirement for a C++ compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,27 @@ cmake_minimum_required( VERSION 3.2 )
 cmake_policy( SET CMP0048 NEW )
 
 #------------------------------------------------------------------------------
+#   Define the project
+#------------------------------------------------------------------------------
+
+#  PROGRAMMING NOTE: SoftFloat doesn't have a numeric version.  Rather, it has
+#  an alphabetic version: '3e'.  But numeric versions are preferred since they
+#  can be more easily compared with one another than alphabetic versions.  We
+#  choose "3.5.0" as our version to correspond to version "3e", where '3' is
+#  the major version number and '5' represents the letter 'e', being the fifth
+#  letter of the alphabet.  The '0' is a fix number, and would be incremented
+#  whenever a important bug fix was released.
+
+#------------------------------------------------------------------------------
+
+set( EXTPKG_NAME  "SoftFloat"                                   )
+set( EXTPKG_VERS  "3.5.0"                                       )
+set( EXTPKG_DESC  "Berkeley IEEE Binary Floating-Point Library" )
+
+project( ${EXTPKG_NAME} VERSION ${EXTPKG_VERS} LANGUAGES C )
+set( PROJECT_DESCRIPTION "${EXTPKG_DESC}" CACHE PATH "Project description" FORCE )
+
+#------------------------------------------------------------------------------
 #   Load some handy CMake modules
 #------------------------------------------------------------------------------
 
@@ -27,13 +48,6 @@ endif()
 
 include( ParseBinaryDir )
 ParseBinaryDir()
-
-
-#------------------------------------------------------------------------------
-#   Define the project
-#------------------------------------------------------------------------------
-
-include( project.txt )
 
 
 #------------------------------------------------------------------------------

--- a/SoftFloat_VS2008.vcproj
+++ b/SoftFloat_VS2008.vcproj
@@ -2186,10 +2186,6 @@
 							>
 						</File>
 						<File
-							RelativePath="project.txt"
-							>
-						</File>
-						<File
 							RelativePath="sources.txt"
 							>
 						</File>

--- a/SoftFloat_VS2015.vcxproj
+++ b/SoftFloat_VS2015.vcxproj
@@ -646,7 +646,6 @@
     <Text Include="extra.txt" />
     <Text Include="headers.txt" />
     <Text Include="includes.txt" />
-    <Text Include="project.txt" />
     <Text Include="softfloat.README.txt" />
     <Text Include="sources.txt" />
     <Text Include="targetver.txt" />

--- a/SoftFloat_VS2015.vcxproj.filters
+++ b/SoftFloat_VS2015.vcxproj.filters
@@ -1618,9 +1618,6 @@
     <Text Include="includes.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>
-    <Text Include="project.txt">
-      <Filter>Other Files\build\cmake\includes</Filter>
-    </Text>
     <Text Include="sources.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>

--- a/SoftFloat_VS2017.vcxproj
+++ b/SoftFloat_VS2017.vcxproj
@@ -646,7 +646,6 @@
     <Text Include="extra.txt" />
     <Text Include="headers.txt" />
     <Text Include="includes.txt" />
-    <Text Include="project.txt" />
     <Text Include="softfloat.README.txt" />
     <Text Include="sources.txt" />
     <Text Include="targetver.txt" />

--- a/SoftFloat_VS2017.vcxproj.filters
+++ b/SoftFloat_VS2017.vcxproj.filters
@@ -1618,9 +1618,6 @@
     <Text Include="includes.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>
-    <Text Include="project.txt">
-      <Filter>Other Files\build\cmake\includes</Filter>
-    </Text>
     <Text Include="sources.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>

--- a/SoftFloat_VS2019.vcxproj
+++ b/SoftFloat_VS2019.vcxproj
@@ -646,7 +646,6 @@
     <Text Include="extra.txt" />
     <Text Include="headers.txt" />
     <Text Include="includes.txt" />
-    <Text Include="project.txt" />
     <Text Include="softfloat.README.txt" />
     <Text Include="sources.txt" />
     <Text Include="targetver.txt" />

--- a/SoftFloat_VS2019.vcxproj.filters
+++ b/SoftFloat_VS2019.vcxproj.filters
@@ -1618,9 +1618,6 @@
     <Text Include="includes.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>
-    <Text Include="project.txt">
-      <Filter>Other Files\build\cmake\includes</Filter>
-    </Text>
     <Text Include="sources.txt">
       <Filter>Other Files\build\cmake\includes</Filter>
     </Text>

--- a/cmake/modules/ParseBinaryDir.cmake
+++ b/cmake/modules/ParseBinaryDir.cmake
@@ -40,12 +40,6 @@ Remove the 'CMakeCache.txt' file and the entire 'CMakeFiles' directory and try a
     endif()
 
     #--------------------------------------------------------------------------
-    #   Enable C/C++ language
-    #--------------------------------------------------------------------------
-    
-    enable_language( C CXX )
-
-    #--------------------------------------------------------------------------
     #   Check if this is a BIG ENDIAN or LITTLE ENDIAN build system.
     #   Some packages needs to know this.
     #--------------------------------------------------------------------------

--- a/project.txt
+++ b/project.txt
@@ -2,6 +2,21 @@
 #   Define the project
 #------------------------------------------------------------------------------
 
+# This file is no longer used!
+
+# From: https://cmake.org/cmake/help/v3.2/command/project.html
+#
+# The top-level CMakeLists.txt file for a project must contain a literal,
+# direct call to the project() command; loading one through the include()
+# command is not sufficient. If no such call exists, CMake will issue a
+# warning and pretend there is a project(Project) at the top to enable the
+# default languages (C and CXX).
+#
+# Note Call the project() command near the top of the top-level CMakeLists.txt,
+# but after calling cmake_minimum_required(). It is important to establish
+# version and policy settings before invoking other commands whose behavior
+# they may affect. See also policy CMP0000.
+
 #  PROGRAMMING NOTE: SoftFloat doesn't have a numeric version.  Rather, it has
 #  an alphabetic version: '3e'.  But numeric versions are preferred since they
 #  can be more easily compared with one another than alphabetic versions.  We
@@ -12,11 +27,11 @@
 
 #------------------------------------------------------------------------------
 
-set( EXTPKG_NAME  "SoftFloat"                                   )
-set( EXTPKG_VERS  "3.5.0"                                       )
-set( EXTPKG_DESC  "Berkeley IEEE Binary Floating-Point Library" )
-
-project( ${EXTPKG_NAME} VERSION ${EXTPKG_VERS} )
-set( PROJECT_DESCRIPTION "${EXTPKG_DESC}" CACHE PATH "Project description" FORCE )
+# set( EXTPKG_NAME  "SoftFloat"                                   )
+# set( EXTPKG_VERS  "3.5.0"                                       )
+# set( EXTPKG_DESC  "Berkeley IEEE Binary Floating-Point Library" )
+#
+# project( ${EXTPKG_NAME} VERSION ${EXTPKG_VERS} LANGUAGES C)
+# set( PROJECT_DESCRIPTION "${EXTPKG_DESC}" CACHE PATH "Project description" FORCE )
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
This change removes the requirement for a C++ compiler to be present for CMAKE.  This is sometimes the situation on certain Linux distributions and removes a stumbling block for novice builders.

**`CMakeLists.txt:`**

From: https://cmake.org/cmake/help/latest/command/project.html

> The top-level `CMakeLists.txt` file for a project must contain a literal, direct call to the `project()` command; loading one through the `include()` command is not sufficient. If no such call exists, CMake will issue a warning and pretend there is a `project(Project)` at the top to enable the default languages (`C` and `CXX`).
> 
> **Note:** Call the `project()` command near the top of the top-level `CMakeLists.txt`, but _after_ calling `cmake_minimum_required()`. It is important to establish version and policy settings before invoking other commands whose behavior they may affect. See also policy `CMP0000`.

**`ParseBinaryDir.cmake:`**

Move requirement for languages to `CMakeLists.txt`'s `project()` statement. Remove requirement for C++.